### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-kubojs",
-  "version": "3.36.3",
+  "version": "0.1.0",
   "description": "A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
   "keywords": [
     "better-auth",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/cli": {
       "name": "create-kubojs",
-      "version": "3.36.3",
+      "version": "0.1.0",
       "bin": {
         "create-kubojs": "dist/cli.mjs",
         "kubojs": "dist/cli.mjs",
@@ -156,9 +156,9 @@
     },
     "packages/template-generator": {
       "name": "@kubojs/template-generator",
-      "version": "3.36.3",
+      "version": "0.1.0",
       "dependencies": {
-        "@kubojs/types": "^3.36.3",
+        "@kubojs/types": "^0.1.0",
         "better-result": "^2.9.2",
         "handlebars": "^4.7.9",
         "memfs": "^4.57.2",
@@ -178,7 +178,7 @@
     },
     "packages/types": {
       "name": "@kubojs/types",
-      "version": "3.36.3",
+      "version": "0.1.0",
       "dependencies": {
         "zod": "^4.4.3",
       },

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubojs/template-generator",
-  "version": "3.36.3",
+  "version": "0.1.0",
   "description": "Virtual file system generator for kubojs templates - works in browsers and Node.js",
   "keywords": [
     "cli",
@@ -48,7 +48,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kubojs/types": "^3.36.3",
+    "@kubojs/types": "^0.1.0",
     "better-result": "^2.9.2",
     "handlebars": "^4.7.9",
     "memfs": "^4.57.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubojs/types",
-  "version": "3.36.3",
+  "version": "0.1.0",
   "description": "TypeScript types and schemas for kubojs CLI",
   "keywords": [
     "cli",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kubojs",
-  "version": "3.36.3",
+  "version": "0.1.0",
   "description": "Let your AI scaffold and extend projects with kubojs. Bundles the kubojs MCP server plus skills, commands, and an agent so the assistant plans a valid stack and generates it instead of hand-rolling boilerplate.",
   "author": {
     "name": "Aman Varshney",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kubojs",
-  "version": "3.36.3",
+  "version": "0.1.0",
   "description": "Let your AI scaffold and extend projects with kubojs. Bundles the kubojs MCP server plus skills so the assistant plans a valid stack and generates it instead of hand-rolling boilerplate.",
   "author": {
     "name": "Aman Varshney",


### PR DESCRIPTION
## Release v0.1.0

This PR bumps the version to `0.1.0` and, once merged, triggers the production Release workflow to publish to npm as **latest**.

### Changes
- Updated `create-kubojs` to v0.1.0
- Updated `@kubojs/types` to v0.1.0
- Updated `@kubojs/template-generator` to v0.1.0
- Updated the agent plugin manifests (Claude Code + Codex) to v0.1.0