### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-kubojs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations",
   "keywords": [
     "better-auth",

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/cli": {
       "name": "create-kubojs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "create-kubojs": "dist/cli.mjs",
         "kubojs": "dist/cli.mjs",
@@ -156,9 +156,9 @@
     },
     "packages/template-generator": {
       "name": "@kubojs/template-generator",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@kubojs/types": "^0.1.0",
+        "@kubojs/types": "^0.1.1",
         "better-result": "^2.9.2",
         "handlebars": "^4.7.9",
         "memfs": "4.65.0",
@@ -178,7 +178,7 @@
     },
     "packages/types": {
       "name": "@kubojs/types",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "zod": "^4.4.3",
       },

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubojs/template-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Virtual file system generator for kubojs templates - works in browsers and Node.js",
   "keywords": [
     "cli",
@@ -48,7 +48,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@kubojs/types": "^0.1.0",
+    "@kubojs/types": "^0.1.1",
     "better-result": "^2.9.2",
     "handlebars": "^4.7.9",
     "memfs": "4.65.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubojs/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript types and schemas for kubojs CLI",
   "keywords": [
     "cli",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kubojs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Let your AI scaffold and extend projects with kubojs. Bundles the kubojs MCP server plus skills, commands, and an agent so the assistant plans a valid stack and generates it instead of hand-rolling boilerplate.",
   "author": {
     "name": "Aman Varshney",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kubojs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Let your AI scaffold and extend projects with kubojs. Bundles the kubojs MCP server plus skills so the assistant plans a valid stack and generates it instead of hand-rolling boilerplate.",
   "author": {
     "name": "Aman Varshney",


### PR DESCRIPTION
## Release v0.1.1

This PR bumps the version to `0.1.1`.

### Changes
- Updated `create-kubojs` to v0.1.1
- Updated `@kubojs/types` to v0.1.1
- Updated `@kubojs/template-generator` to v0.1.1
- Updated the agent plugin manifests (Claude Code + Codex) to v0.1.1

### Preview Release
A preview release will be published automatically and posted as a PR comment.

---
*Created by release flow for 0.1.1*