### PR TITLE
fix(cli): preserve Neon command arguments on Windows

### DIFF
--- a/apps/cli/src/helpers/database-providers/neon-setup.ts
+++ b/apps/cli/src/helpers/database-providers/neon-setup.ts
@@ -24,6 +24,8 @@ import {
   resolveDbSetupMode,
 } from "../core/db-setup-options";
 
+const NEON_REFERRAL = "sbA3tIe";
+
 type NeonConfig = {
   connectionString: string;
   projectId: string;
@@ -51,11 +53,11 @@ const NEON_REGIONS: NeonRegion[] = [
 
 async function executeNeonCommand(
   packageManager: PackageManager,
-  commandArgsString: string,
+  commandArgs: readonly string[],
   spinnerText?: string,
 ): Promise<Result<{ stdout: string; stderr: string }, DatabaseSetupError>> {
   const s = createSpinner();
-  const args = getPackageExecutionArgs(packageManager, commandArgsString);
+  const args = getPackageExecutionArgs(packageManager, commandArgs);
 
   if (spinnerText) s.start(spinnerText);
 
@@ -82,10 +84,19 @@ async function createNeonProject(
   regionId: string,
   packageManager: PackageManager,
 ): Promise<Result<NeonConfig, DatabaseSetupError>> {
-  const commandArgsString = `neonctl@latest projects create --name ${projectName} --region-id ${regionId} --output json`;
   const execResult = await executeNeonCommand(
     packageManager,
-    commandArgsString,
+    [
+      "neonctl@latest",
+      "projects",
+      "create",
+      "--name",
+      projectName,
+      "--region-id",
+      regionId,
+      "--output",
+      "json",
+    ],
     `Creating Neon project "${projectName}"...`,
   );
 
@@ -180,10 +191,12 @@ async function setupWithNeonDb(
     return ensureDirResult;
   }
 
-  const packageArgs = getPackageExecutionArgs(
-    packageManager,
-    `neon-new@latest --yes --ref "sbA3tIe"`,
-  );
+  const packageArgs = getPackageExecutionArgs(packageManager, [
+    "neon-new@latest",
+    "--yes",
+    "--ref",
+    NEON_REFERRAL,
+  ]);
 
   return Result.tryPromise({
     try: async () => {
@@ -194,11 +207,29 @@ async function setupWithNeonDb(
       s.stop(pc.red("Failed to create database with neon-new"));
       return new DatabaseSetupError({
         provider: "neon",
-        message: `Failed to create database with neon-new: ${e instanceof Error ? e.message : String(e)}`,
+        message: formatNeonCommandError(e),
         cause: e,
       });
     },
   });
+}
+
+function formatNeonCommandError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (
+    process.platform === "win32" &&
+    message.includes("ERR_UNSUPPORTED_ESM_URL_SCHEME") &&
+    message.includes("protocol 'c:'")
+  ) {
+    return [
+      "Failed to create database with neon-new: the Neon CLI returned an invalid Windows file URL.",
+      "Use the Manual Neon setup for now, or update neon-new if a newer release is available.",
+      `Original error: ${message}`,
+    ].join(" ");
+  }
+
+  return `Failed to create database with neon-new: ${message}`;
 }
 
 function displayManualSetupInstructions(target: "apps/web" | "apps/server") {

--- a/apps/cli/src/utils/package-runner.ts
+++ b/apps/cli/src/utils/package-runner.ts
@@ -48,6 +48,8 @@ function splitCommandArgs(commandWithArgs: string): string[] {
   return args;
 }
 
+export type PackageCommand = string | readonly string[];
+
 /**
  * Returns the appropriate command for running a package without installing it globally,
  * based on the selected package manager.
@@ -80,9 +82,11 @@ export function getPackageExecutionCommand(
  */
 export function getPackageExecutionArgs(
   packageManager: PackageManager | null | undefined,
-  commandWithArgs: string,
+  commandWithArgs: PackageCommand,
 ): string[] {
-  const args = splitCommandArgs(commandWithArgs);
+  const args = Array.isArray(commandWithArgs)
+    ? [...commandWithArgs]
+    : splitCommandArgs(commandWithArgs);
   switch (packageManager) {
     case "pnpm":
       return ["pnpm", "dlx", ...args];

--- a/apps/cli/test/package-runner.test.ts
+++ b/apps/cli/test/package-runner.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { getPackageExecutionArgs } from "../src/utils/package-runner";
+
+describe("package runner", () => {
+  it("preserves argument boundaries for Windows-compatible provider commands", () => {
+    expect(
+      getPackageExecutionArgs("bun", [
+        "neonctl@latest",
+        "projects",
+        "create",
+        "--name",
+        "my Windows app",
+        "--region-id",
+        "aws-us-east-1",
+      ]),
+    ).toEqual([
+      "bunx",
+      "neonctl@latest",
+      "projects",
+      "create",
+      "--name",
+      "my Windows app",
+      "--region-id",
+      "aws-us-east-1",
+    ]);
+  });
+
+  it("continues to support the string command form", () => {
+    expect(getPackageExecutionArgs("npm", 'neon-new@latest --ref "sbA3tIe"')).toEqual([
+      "npx",
+      "neon-new@latest",
+      "--ref",
+      "sbA3tIe",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve command argument boundaries when invoking package managers on Windows
- run Neon setup with argv arrays and improve the Windows ESM URL-scheme error
- add regression coverage for Windows-compatible package commands

## Validation
- bun run build:cli
- bun test test/package-runner.test.ts test/cli-validation.test.ts test/testing-setup.test.ts
- manual Windows Neon automatic setup completed successfully

No GitHub Actions windows-latest test was added, as requested.